### PR TITLE
fix scrolling in map folder chooser

### DIFF
--- a/src/MapChooser.as
+++ b/src/MapChooser.as
@@ -143,7 +143,10 @@ namespace MapChooser {
         chooseFolderBtnWidth = UI::GetCursorPos().x - pos.x - framePadding.x * 2.;
         UI::Dummy(vec2());
         UI::Separator();
-        DrawFolderSelector();
+        if (UI::BeginChild("choose folder scollable")) {
+            DrawFolderSelector();
+        }
+        UI::EndChild();
     }
 
     void OnClickSelectAll() {


### PR DESCRIPTION
This moves the scrollbar in the map chooser "From Folder" into the folder section so that the top buttons remain visible while scrolling through maps.
![image](https://user-images.githubusercontent.com/52106022/230698412-83c5909b-9f01-47b8-8ab8-a1515c6b1dd8.png)
