### PR TITLE
Missing New Setting S_EnableJoinLeaveNotifications

### DIFF
--- a/src/API/Http.as
+++ b/src/API/Http.as
@@ -31,12 +31,12 @@ Json::Value@ FetchClubEndpoint(const string &in route) {
 
 Json::Value@ CallLiveApiPath(const string &in path) {
     AssertGoodPath(path);
-    return FetchLiveEndpoint(NadeoServices::BaseURL() + path);
+    return FetchLiveEndpoint(NadeoServices::BaseURLLive() + path);
 }
 
 Json::Value@ PostLiveApiPath(const string &in path, Json::Value@ data) {
     AssertGoodPath(path);
-    return PostLiveEndpoint(NadeoServices::BaseURL() + path, data);
+    return PostLiveEndpoint(NadeoServices::BaseURLLive() + path, data);
 }
 
 Json::Value@ CallCompApiPath(const string &in path) {

--- a/src/GameModeSettings.as
+++ b/src/GameModeSettings.as
@@ -77,7 +77,8 @@ S_UseCustomPointsRepartition,,,,1,,
 S_UseTieBreak,,,,1,,
 S_WarmUpDuration,1,1,1,1,1,1
 S_WarmUpNb,1,1,1,1,1,1
-S_WarmUpTimeout,1,1,1,1,1,1""";
+S_WarmUpTimeout,1,1,1,1,1,1
+S_EnableJoinLeaveNotifications,1,1,1,1,1,1""";
 
 string[][]@ _GetGameModeValidOpts() {
     auto lines = GameModeCSV.Split("\n");
@@ -159,6 +160,7 @@ dictionary@ _GetSettingsToType() {
     ret["S_WarmUpNb"] = "integer";
     ret["S_WarmUpTimeout"] = "integer";
     ret["S_WinnersRatio"] = "Float";
+    ret["S_EnableJoinLeaveNotifications"] = "boolean";
     return ret;
 }
 


### PR DESCRIPTION
I looks like they added a new setting to all the game modes called `S_EnableJoinLeaveNotifications`.

From extracted ModeBase.Script.txt:
```
#Setting S_EnableJoinLeaveNotifications True as _("Enable join and leave notifications") ///< Display a notification when a player joins or leaves the server
```

I also went ahead and updated the call to NadeoServices::BaseURL because it was spamming the log with deprecation warnings:
```
DEPRECATED: For the Live API, you should use NadeoServices::BaseURLLive() instead of BaseURL().
```