### PR TITLE
Move ServerJoin sleep to after var check

### DIFF
--- a/src/WatchForServerJoin.as
+++ b/src/WatchForServerJoin.as
@@ -28,8 +28,8 @@ namespace WatchServer {
         auto si = cast<CTrackManiaNetworkServerInfo>(app.Network.ServerInfo);
         auto declaredVars = tostring(app.Network.ClientManiaAppPlayground.Dbg_DumpDeclareForVariables(si.TeamProfile1, false));
         while (app.Network.ClientManiaAppPlayground !is null && !declaredVars.Contains("Net_DecoImage_ClubId = ")) {
-            sleep(1000);
             declaredVars = tostring(app.Network.ClientManiaAppPlayground.Dbg_DumpDeclareForVariables(si.TeamProfile1, false));
+            sleep(1000);
         }
         auto parts = declaredVars.Split("Net_DecoImage_ClubId = ");
         if (parts.Length <= 1) return;


### PR DESCRIPTION
There is a niche case where if you leave a server in the 1 second between the `while` condition being checked and the next call to Dbg_DumpDeclareForVariables() you will get a script exception:

```
Script exception: Null pointer access
  ./src/WatchForServerJoin.as (line 32, column 13)
    #0  void WatchServer::OnJoinedServer() (./BetterRoomManager/src/WatchForServerJoin.as line 32)
```

This change will result in the while loop making the call immediately after performing the null check and then doing the wait before continuing the loop.

I was on the map review server when I saw this occur. I guess maybe they dont have that variable on map review so it was stuck in the loop until I left.