### PR TITLE
enable the tab popout functionality for roomtab

### DIFF
--- a/src/MainUI.as
+++ b/src/MainUI.as
@@ -27,6 +27,7 @@ void RenderMenu() {
 
 void RenderMainUI() {
     RenderRoomManagerWindow();
+    RenderPoppedOutWindows();
     RenderAddMapWindow();
 }
 
@@ -46,6 +47,19 @@ void RenderRoomManagerWindow() {
         UI::EndDisabled();
     }
     UI::End();
+}
+
+void RenderPoppedOutWindows() {
+    if (!WindowOpen) return;
+    vec2 size = vec2(1200, 700);
+    vec2 pos = (vec2(Draw::GetWidth(), Draw::GetHeight()) - size) / 2.;
+    for (uint i = 0; i < mainTabs.Length; i++) {
+        UI::SetNextWindowSize(int(size.x), int(size.y), UI::Cond::FirstUseEver);
+        UI::SetNextWindowPos(int(pos.x), int(pos.y), UI::Cond::FirstUseEver);
+        UI::BeginDisabled(IsAnyChooserActive());
+        mainTabs[i].DrawWindow();
+        UI::EndDisabled();
+    }
 }
 
 array<Tab@> mainTabs;

--- a/src/Tabs/RoomTab.as
+++ b/src/Tabs/RoomTab.as
@@ -15,11 +15,15 @@ class RoomTab : Tab {
     bool isEditing = true;
     bool isActive = true;
 
+    int get_WindowFlags() override {
+        return UI::WindowFlags::NoCollapse;
+    }
+
     // roomId = -1 to create a new room
     RoomTab(RoomsTab@ parent, int _roomId, const string &in roomName, bool public, bool isActive) {
         isEditing = _roomId > 0;
         this.roomName = isEditing ? roomName : "New Room";
-        super(Icons::Server + " " + this.roomName + "\\$z (" + _roomId + ")", false);
+        super(Icons::Server + " " + this.roomName + "\\$z (" + _roomId + ")", true);
         // have to set isEditing again for some reason -- weird.
         isEditing = _roomId > 0;
         this.isActive = isActive;


### PR DESCRIPTION
additionally add loop to main ui render that tries to draw the tabs as windows. since tabopen and windowopen are mutually exclusive this seems to work as is.

from a testing perspective, i was able to load and edit multiple rooms in a club at the same time while they are popped out. since the popout functionality was already sort of built in; i didnt do that deep of testing